### PR TITLE
Fix for #471 & #472: Set hierarchical presentation as default

### DIFF
--- a/eclipse/workspace/setup/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml
+++ b/eclipse/workspace/setup/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section name="Workbench">
+	<section name="org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart">
+		<item value="1" key="layout"/>
+	</section>
+</section>


### PR DESCRIPTION
Fix for [#471](https://github.com/devonfw/ide/issues/471) & [#472](https://github.com/devonfw/ide/issues/472) in [devonfw/ide](https://github.com/devonfw/ide) repository.

When creating a new workspace, the default project & package presentation will be hierarchical.