### PR TITLE
Fix for #473: Disabled warning for missing serialVersionUID

### DIFF
--- a/eclipse/workspace/setup/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs
+++ b/eclipse/workspace/setup/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,1 @@
+org.eclipse.jdt.core.compiler.problem.missingSerialVersion=ignore


### PR DESCRIPTION
Fix for [#473](https://github.com/devonfw/ide/issues/473) in [devonfw/ide](https://github.com/devonfw/ide)

