### PR TITLE
disable telemetry of vs code

### DIFF
--- a/vscode/conf/vscode/setup/User/settings.json
+++ b/vscode/conf/vscode/setup/User/settings.json
@@ -1,0 +1,9 @@
+{
+    "redhat.telemetry.enabled": false,
+    "telemetry.enableCrashReporter": false,
+    "gitlens.advanced.telemetry.enabled": false,
+    "telemetry.enableTelemetry": false,
+    "code-runner.enableAppInsights": false,
+    "rest-client.enableTelemetry": false,
+    "githubPullRequests.telemetry.enabled": false
+}

--- a/vscode/conf/vscode/update/User/settings.json
+++ b/vscode/conf/vscode/update/User/settings.json
@@ -1,0 +1,9 @@
+{
+    "redhat.telemetry.enabled": false,
+    "telemetry.enableCrashReporter": false,
+    "gitlens.advanced.telemetry.enabled": false,
+    "telemetry.enableTelemetry": false,
+    "code-runner.enableAppInsights": false,
+    "rest-client.enableTelemetry": false,
+    "githubPullRequests.telemetry.enabled": false
+}


### PR DESCRIPTION
VS Code sends home some telemetry.

For our project that is not acceptable.

This commit contains the configuration necessary for disabling telemetry.

Note that devon-ide needs to be patched, by default it will not update the directory added here.