### PR TITLE
#1026: Focus on LTS releases by default

### DIFF
--- a/devon.properties
+++ b/devon.properties
@@ -6,3 +6,8 @@
 # Uncomment the following line to get the legacy default config back for the settings
 #SETTINGS_PATH=${DEVON_IDE_HOME}/workspaces/main/development/settings
 
+# LTS versions
+DOTNET_VERSION=6*
+JAVA_VERSION=17*
+NODE_VERSION=v18*
+PYTHON_VERSION=3.11*


### PR DESCRIPTION
This PR adds LTS versions for some tools. Most of the tools does not follow the LTS strategy, so it is not possible to define a proper version.

Related issue: https://github.com/devonfw/ide/issues/1026