### PR TITLE
#1147: separate plugins from software

### DIFF
--- a/android-studio/workspace/update/idea.properties
+++ b/android-studio/workspace/update/idea.properties
@@ -1,4 +1,4 @@
 idea.config.path=${WORKSPACE_PATH}/.android-studio/config
 idea.system.path=${WORKSPACE_PATH}/.android-studio/system
-idea.plugins.path=${DEVON_IDE_HOME}/software/android-studio-plugins
+idea.plugins.path=${DEVON_IDE_HOME}/plugins/android-studio
 idea.log.path=${WORKSPACE_PATH}/.android-studio/system/log

--- a/intellij/workspace/update/idea.properties
+++ b/intellij/workspace/update/idea.properties
@@ -1,4 +1,4 @@
 idea.config.path=${WORKSPACE_PATH}/.intellij/config
 idea.system.path=${WORKSPACE_PATH}/.intellij/system
-idea.plugins.path=${DEVON_IDE_HOME}/software/intellij-plugins
+idea.plugins.path=${DEVON_IDE_HOME}/plugins/intellij
 idea.log.path=${WORKSPACE_PATH}/.intellij/system/log


### PR DESCRIPTION
Addresses/Fixes: [#1147](https://github.com/devonfw/ide/issues/1147), [#1259](https://github.com/devonfw/ide/issues/1259)

Implements:

* changed intellij plugins directory from software/intellij-plugins to plugins/intellij
* changed android-studio plugins directory from software/android-studio-plugins to plugins/android-studio