### PR TITLE
fix import options tabs 

### DIFF
--- a/intellij/workspace/update/.intellij/config/codestyles/Default.xml
+++ b/intellij/workspace/update/.intellij/config/codestyles/Default.xml
@@ -7,6 +7,8 @@
     <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
     <option name="JD_P_AT_EMPTY_LINES" value="false" />
     <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
   </JavaCodeStyleSettings>
   <codeStyleSettings language="Groovy">
     <indentOptions>


### PR DESCRIPTION
Fixes the `Settings - Editor - Code Style - Java - Tab "Imports"` part of the issue: https://github.com/devonfw/IDEasy/issues/52



