### PR TITLE
#52: Intellij import options

### DIFF
--- a/intellij/workspace/setup/.idea/eclipseCodeFormatter.xml
+++ b/intellij/workspace/setup/.idea/eclipseCodeFormatter.xml
@@ -4,7 +4,7 @@
     <option name="projectSpecificProfile">
       <ProjectSpecificProfile>
         <option name="eclipseVersion" value="CUSTOM" />
-        <option name="formatter" value="ECLIPSE" />
+        <!-- <option name="formatter" value="ECLIPSE" /> -->
         <option name="pathToConfigFileJava" value="${DEVON_IDE_HOME}/settings/eclipse/ide-code-style.xml" />
         <option name="selectedJavaProfile" value="IDE" />
       </ProjectSpecificProfile>

--- a/intellij/workspace/setup/.idea/encodings.xml
+++ b/intellij/workspace/setup/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>

--- a/intellij/workspace/setup/.idea/inspectionProfiles/profiles_settings.xml
+++ b/intellij/workspace/setup/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/intellij/workspace/setup/.idea/workspace.xml
+++ b/intellij/workspace/setup/.idea/workspace.xml
@@ -21,6 +21,7 @@
     </option>
   </component>
   <component name="MavenRunner">
+    <option name="jreName" value="Java" />
     <option name="skipTests" value="true" />
     <option name="vmOptions" value="-Xmx8G" />
   </component>

--- a/intellij/workspace/update/.intellij/config/codestyles/Default.xml
+++ b/intellij/workspace/update/.intellij/config/codestyles/Default.xml
@@ -21,7 +21,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="120" />
+    <option name="RIGHT_MARGIN" value="160" />
     <option name="KEEP_LINE_BREAKS" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />


### PR DESCRIPTION
Fixes: https://github.com/devonfw/IDEasy/issues/52

_Small notes on the code solutions:_
* Eclipse had to be disabled in `eclipseCodeFormatter.xml`. Setting `plugin_active=false` in `intellij\plugins\EclipseCodeFormatter.properties` wasn't working for me.
* JavaDoc: there were already detailed settings for the ide, the problem was that intellij was using the project inspectionProfile instead.
* mvn builder  JRE is set as "java"
* I didn´t include `FolderCompact ` plugin because of its downside

