### PR TITLE
#154 show project name in intellij

### DIFF
--- a/intellij/workspace/setup/.idea/.name
+++ b/intellij/workspace/setup/.idea/.name
@@ -1,0 +1,1 @@
+${IDE_HOME} - main

--- a/intellij/workspace/setup/.idea/.name
+++ b/intellij/workspace/setup/.idea/.name
@@ -1,1 +1,1 @@
-${IDE_HOME} - main
+${PROJECT_NAME} - ${WORKSPACE}


### PR DESCRIPTION
Fixes: [#154](https://github.com/devonfw/IDEasy/issues/154)

Implements:
* adds .name file with PROJECT_NAME and WORKSPACE variables to intellij setup