### PR TITLE
#1389:Username for accessing servers via Maven no longer encrypted

### DIFF
--- a/templates/conf/mvn/settings.xml
+++ b/templates/conf/mvn/settings.xml
@@ -17,13 +17,13 @@
    hit return and then type your password (do not supply as argument as otherwise it will be saved to the history of your shell)
    Then copy the encrypted password as according password to this settings.xml
    -->
-  <servers>
-    <server>
-      <id>repository</id>
-      <username>$[mavenRepoLogin]</username>
-      <password>$[mavenRepoPassword]</password>
-    </server>
-  </servers>
+<servers>
+   <server>
+     <id>repository</id>
+     <username>${env.USERNAME}</username>
+     <password>$[mavenRepoPassword]</password>
+   </server>
+ </servers>
 
   <!--
   <mirrors>


### PR DESCRIPTION
fixes devonfw/ide#1389: Username no longer gets encrypted.

However it is still not possible to access servers via Maven since 'C:\projects\_ide\software\default\mvn\mvn\3.9.9\bin\mvn.cmd' is trying to reach settings-security.xml at C:\Users\username\.m2\settings-security.xml
and not at C:\projects\projectname\conf\mvn\settings-security.xml where it is created.

Also the IDE environment variables: M2_REPO and MAVEN_ARGS seem to be buggy since even after reconfiguration they point at the wrong project.

For example in a project named "Test" the M2_REPO and MAVEN_ARGS where set to:
M2_REPO=C:\projects\IDEasy\conf\mvn\repository
 
MAVEN_ARGS=-s C:\projects\IDEasy\conf\mvn\settings.xml
 