### PR TITLE
devonfw/IDEasy#736: encode the "+" character

### DIFF
--- a/intellij/plugins/PlantUMLIntegration.properties
+++ b/intellij/plugins/PlantUMLIntegration.properties
@@ -1,3 +1,3 @@
-plugin_id=PlantUML integration
+plugin_id=PlantUML%20integration
 plugin_active=true
 tags=doc,uml


### PR DESCRIPTION
devonfw/IDEasy#736 fix bug where the + character in the plugin name for the url is not encoded