### PR TITLE
devonfw/IDEasy#768: preconfigure IntelliJ with annotation processing and auto-import

### DIFF
--- a/intellij/workspace/update/.idea/compiler.xml
+++ b/intellij/workspace/update/.idea/compiler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4" xmlns:merge="https://github.com/devonfw/IDEasy/merge">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="true"/>
+    </annotationProcessing>
+  </component>
+</project>

--- a/intellij/workspace/update/.intellij/config/options/editor.xml
+++ b/intellij/workspace/update/.intellij/config/options/editor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<application xmlns:merge="https://github.com/devonfw/IDEasy/merge" version="4">
+  <component name="CodeInsightSettings">
+    <option name="ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY" value="true"/>
+  </component>
+</application>


### PR DESCRIPTION
## Summary

- Add `intellij/workspace/update/.idea/compiler.xml` to enable annotation processing
  by default — required for projects using code-generation (Lombok, MapStruct, etc.)
  and harmless for those that don't
- Add `intellij/workspace/update/.intellij/config/options/editor.xml` to enable
  auto-import of unambiguous imports on save (ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY=true)
- Both files in `update/` so settings are enforced on every IDE restart

## What is NOT changed

- `mavenProjectSettings.xml` already has `passArgLine=true` and is left untouched —
  disabling argLine would break tests relying on JVM args (-javaagent, --add-opens)

Closes #768
