### PR TITLE
devonfw/IDEasy#2104: Remove unnecessary VSCode plugins

### DIFF
--- a/vscode/plugins/cordova-tools.properties
+++ b/vscode/plugins/cordova-tools.properties
@@ -1,3 +1,0 @@
-plugin_id=msjsdiag.cordova-tools
-plugin_active=false
-tags=cordova

--- a/vscode/plugins/docthis.properties
+++ b/vscode/plugins/docthis.properties
@@ -1,3 +1,0 @@
-plugin_id=oouo-diogo-perdigao.docthis
-plugin_active=true
-tags=doc,js

--- a/vscode/plugins/git-graph.properties
+++ b/vscode/plugins/git-graph.properties
@@ -1,3 +1,0 @@
-plugin_id=mhutchie.git-graph
-plugin_active=true
-tags=git

--- a/vscode/plugins/linecount.properties
+++ b/vscode/plugins/linecount.properties
@@ -1,3 +1,0 @@
-plugin_id=yycalm.linecount
-plugin_active=true
-tags=productivity

--- a/vscode/plugins/lorem-ipsum.properties
+++ b/vscode/plugins/lorem-ipsum.properties
@@ -1,3 +1,0 @@
-plugin_id=Tyriar.lorem-ipsum
-plugin_active=true
-tags=generator

--- a/vscode/plugins/polacode.properties
+++ b/vscode/plugins/polacode.properties
@@ -1,3 +1,0 @@
-plugin_id=pnp.polacode
-plugin_active=false
-tags=screenshot

--- a/vscode/plugins/resource-monitor.properties
+++ b/vscode/plugins/resource-monitor.properties
@@ -1,3 +1,0 @@
-plugin_id=mutantdino.resourcemonitor
-plugin_active=true
-tags=monitor,productivity

--- a/vscode/plugins/search-docsets.properties
+++ b/vscode/plugins/search-docsets.properties
@@ -1,3 +1,0 @@
-plugin_id=silverlakesoftware.searchdocsets-vscode
-plugin_active=true
-tags=doc,search

--- a/vscode/plugins/sublime-keybindings.properties
+++ b/vscode/plugins/sublime-keybindings.properties
@@ -1,3 +1,0 @@
-plugin_id=ms-vscode.sublime-keybindings
-plugin_active=true
-tags=keybinging

--- a/vscodium/plugins/cordova-tools.properties
+++ b/vscodium/plugins/cordova-tools.properties
@@ -1,3 +1,0 @@
-plugin_id=msjsdiag.cordova-tools
-plugin_active=false
-tags=cordova

--- a/vscodium/plugins/docthis.properties
+++ b/vscodium/plugins/docthis.properties
@@ -1,3 +1,0 @@
-plugin_id=oouo-diogo-perdigao.docthis
-plugin_active=true
-tags=doc,js

--- a/vscodium/plugins/git-graph.properties
+++ b/vscodium/plugins/git-graph.properties
@@ -1,3 +1,0 @@
-plugin_id=mhutchie.git-graph
-plugin_active=true
-tags=git

--- a/vscodium/plugins/lorem-ipsum.properties
+++ b/vscodium/plugins/lorem-ipsum.properties
@@ -1,3 +1,0 @@
-plugin_id=Tyriar.lorem-ipsum
-plugin_active=true
-tags=generator

--- a/vscodium/plugins/polacode.properties
+++ b/vscodium/plugins/polacode.properties
@@ -1,3 +1,0 @@
-plugin_id=pnp.polacode
-plugin_active=false
-tags=screenshot

--- a/vscodium/plugins/sublime-keybindings.properties
+++ b/vscodium/plugins/sublime-keybindings.properties
@@ -1,3 +1,0 @@
-plugin_id=ms-vscode.sublime-keybindings
-plugin_active=true
-tags=keybinging


### PR DESCRIPTION
### This PR fixes [devonfw#2104](https://github.com/devonfw/IDEasy/issues/2104)

### Implemented changes:

Removed VSCode (and VSCodium) plugins that are abandoned, effectively unused, or a niche personal-preference preset:

| Extension ID | Reason |
|---|---|
| `msjsdiag.cordova-tools` | [See](https://github.com/devonfw/ide-settings/pull/92#pullrequestreview-4673077730). |
| `oouo-diogo-perdigao.docthis` | Abandoned (~2019). This is a niche JSDoc comment generator. VSCodes built-in JS/TS language service now does this natively, therefore no longer relevant. |
| `mhutchie.git-graph` | Abandoned (~2021). VS Code ships a built-in Source Control Graph that covers the same functionality. |
| `yycalm.linecount` | Abandoned (~2014). Simple line-of-code counter, this functionality is now available through the built-in status bar selection count. |
| `Tyriar.lorem-ipsum` | Lorem ipsum generator, a convenience rarely needed in real development workflow, therefore there's little reason to ship this by default. |
| `pnp.polacode` | Generates polaroid-style screenshots of code snippets, no development value (+ might be buggy, I was not able to find it in the installed extensions list in my VSCode instance). |
| `mutantdino.resourcemonitor` | Abandoned (~2015). Has known CPU-usage bugs on Windows, maybe could be replaced with something else.
| `silverlakesoftware.searchdocsets-vscode` | Abandoned (~2015). Requires external Dash/Zeal apps which makes it useless for most users. |
| `ms-vscode.sublime-keybindings` | Sublime is rarely used nowadays and I would consider an extension just for it's keybindings a personal preference. |